### PR TITLE
Exempt dependabot from stale PR closure

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -32,6 +32,7 @@ jobs:
           days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
           days-before-pr-close: ${{ inputs.days-before-pr-close }}
           exempt-draft-pr: true
+          exempt-pr-labels: dependencies
           operations-per-run: 5000
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
On the FMS team, we are running into some dependabot PRs that we are not able to get to within 15 days. This commit exempts all PRs with a `dependencies` tag from being auto-closed.

I realize that this behavior may not be desired for all engineering teams, so if it is possible to override this in `fleet_planner` specifically, that might be ideal. If not, we will do our current method of rebasing the PR with dependabot to keep it fresh.